### PR TITLE
Fix typo in clone command

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ After installation, you can use Synthego ICE as a module (see  [python_example.p
 After installing via pip, grab the example data by cloning this repository:
 
 ```bash
-git clone git@github.com:synthego-open/ice.git ice
+git clone git@github.com/synthego-open/ice.git ice
 
 cd ice # change into the ice directory
 ```


### PR DESCRIPTION
Fix typo in `git clone` command