### PR TITLE
Dev/com update contrib files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ nosetests.xml
 coverage.xml
 *.cover
 .hypothesis/
+test-reports/
 
 # Environments
 .env

--- a/ice/classes/edit_proposal.py
+++ b/ice/classes/edit_proposal.py
@@ -30,9 +30,13 @@ from ice.classes.proposal_base import ProposalBase
 
 
 class EditProposal:
-    """This class is to store the data for one edit proposal"""
+    """
+    Stores the edit information for a single proposal.
+    """
+    def __init__(self, wildtype=False):
+        # if proposal is wildtype
+        self.wildtype = wildtype
 
-    def __init__(self):
         # list of ProposalBases
         self.sequence_data = None
 
@@ -49,6 +53,9 @@ class EditProposal:
 
         # more comprehensive code for bases_changed
         self.summary = None
+
+        # details of bases changed in json format
+        self.summary_json = None
 
         # absolute and relative coefficients from the regression
         self.x_rel = None

--- a/ice/classes/sanger_analysis.py
+++ b/ice/classes/sanger_analysis.py
@@ -152,6 +152,13 @@ class SangerAnalysis:
         self.donor_odn = donor
         return True
 
+    @property
+    def multiplex(self):
+        """
+        :return: bool indicating if sanger analysis is multiplex
+        """
+        return len(self.guide_targets) > 1
+
     def quality_check(self):
         aw = self.edited_sample.find_alignable_window()
         if aw['max_window'] is None:

--- a/ice/outputs/create_json.py
+++ b/ice/outputs/create_json.py
@@ -47,11 +47,11 @@ def write_contribs_json(sanger_analysis, to_file):
         if entry.x_rel > 0.0:
             abundance = round(entry.x_rel, 3)
             wt = False
-            if entry.summary == 0:
+            if entry.bases_changed == 0:
                 wt = True
             out_list.append({'rel_abundance': abundance,
                              'human_readable': entry.human_readable_sequence(),
-                             'indel': entry.summary, 'wt': wt})
+                             'indel': {'summary': entry.summary, 'total': entry.bases_changed}, 'wt': wt})
 
     editing_outcomes = {}
 

--- a/ice/outputs/create_json.py
+++ b/ice/outputs/create_json.py
@@ -46,19 +46,15 @@ def write_contribs_json(sanger_analysis, to_file):
     for entry in sanger_analysis.results.contribs:
         if entry.x_rel > 0.0:
             abundance = round(entry.x_rel, 3)
-            wt = False
-            if entry.bases_changed == 0:
-                wt = True
             out_list.append({'rel_abundance': abundance,
                              'human_readable': entry.human_readable_sequence(),
-                             'indel': {'summary': entry.summary, 'total': entry.bases_changed}, 'wt': wt})
+                             'indel': entry.summary_json, 'wt': entry.wildtype})
 
     editing_outcomes = {}
-
     for i in sanger_analysis.results.aggregate:
         editing_outcomes[i] = round(sanger_analysis.results.aggregate[i] * 100, 2)
 
-    output = {'contribs_list': out_list, 'editing_outcomes': editing_outcomes}
+    output = {'contribs_list': out_list, 'editing_outcomes': editing_outcomes, 'multiplex': sanger_analysis.multiplex}
 
     with open(to_file, 'w') as out_file:
         json.dump(output, out_file)

--- a/ice/tests/test_edit_proposal_creator.py
+++ b/ice/tests/test_edit_proposal_creator.py
@@ -20,31 +20,49 @@ def test_single_cut():
     assert bad_config.sequence == "ACCTGTCCCCATAGAAAT"
 
 
-def test_pretty_print():
-    wt_basecalls = "GCACCTGTCCCCATAGAAAT"
+def test_human_readable_sequence_single_edit_proposal():
+    wt_basecalls = 'ACTGCCTGCACCTGTCCCCATAGAAATCCGCTTTACGGAGAGTCACTAGACTAGGACCCCCATAAATTTCACGACAGGGACTAGACCTTGACTGGATA'
+    epc = EditProposalCreator(wt_basecalls, use_ctrl_trace=False)
+    proposal = epc.single_cut_edit_proposal(27, 'g1', del_before=4)
+
+    # test default padding
+    seq = proposal.human_readable_sequence()
+    assert seq == 'TGCCTGCACCTGTCCCCATAG----|CCGCTTTACGGAGAGTCACTAGACTAGGACCCCCATAAATTTCACGACAG'
+
+    # test custom padding
+    seq = proposal.human_readable_sequence(bp_before_cutsite=10, bp_after_cutsite=15)
+    assert seq == 'CCATAG----|CCGCTTTACGGAGAG'
+
+    # test passing in out of bounds padding values (should default to returning the entire proposed sequence)
+    seq = proposal.human_readable_sequence(bp_before_cutsite=500, bp_after_cutsite=500)
+    assert seq == 'ACTGCCTGCACCTGTCCCCATAG----|CCGCTTTACGGAGAGTCACTAGACTAGGACCCCCATAAATTTCACGACAGGGACTAGACCTTGACTGGAT'
+
+    # test passing in inf values (should return the the entire proposed sequence)
+    seq = proposal.human_readable_sequence(bp_before_cutsite=float('inf'), bp_after_cutsite=float('inf'))
+    assert seq == 'ACTGCCTGCACCTGTCCCCATAG----|CCGCTTTACGGAGAGTCACTAGACTAGGACCCCCATAAATTTCACGACAGGGACTAGACCTTGACTGGAT'
+
+
+def test_human_readable_sequence_multiplex_proposal():
+    wt_basecalls = ('CCCATAAATCCGCTTTACAGTCACTAGACTAGGACCAATTTCACGACAGGGACTAGACCTTGCTGGATAGCACCTGTCCCCATAGAAATGGCTATGGA'
+                    'AAGCCTTTGGGTTATTTGCGGCACCTGTCCCCATAGAAATGGCTATGGAAAGCCTTTGGGTTATTTGCG')
     epc = EditProposalCreator(wt_basecalls, use_ctrl_trace=False)
 
-    with pytest.raises(Exception) as e:
-        proposal = epc.single_cut_edit_proposal(10, "test", del_before=4)
-        proposal.human_readable_sequence()
+    # test close together dropout default padding
+    close_together_dropout_proposal = epc.multiplex_proposal(30, 50, 'g1', 'g2', dropout=True)
+    seq = close_together_dropout_proposal.human_readable_sequence()
+    assert seq == 'AAATCCGCTTTACAGTCACTAGACT|--------------------|GACTAGACCTTGCTGGATAGCACCTGTCCC'
 
-    proposal = epc.single_cut_edit_proposal(10, "test", del_before=4)
-    seq = proposal.human_readable_sequence(bp_before_cutsite=9, bp_after_cutsite=3)
+    # test far apart dropout default padding
+    far_apart_dropout_proposal = epc.multiplex_proposal(30, 90, 'g1', 'g2', dropout=True)
+    seq = far_apart_dropout_proposal.human_readable_sequence()
+    assert seq == ('AAATCCGCTTTACAGTCACTAGACT|------------------------------------------------------------|GCTATGGAAAGC'
+                    'CTTTGGGTTATTT')
 
-    assert seq == "CACCT----|CCA"
-
-def test_pretty_print2():
-    wt_basecalls = "GCACCTGTCCCCATAGAAAT"
-    epc = EditProposalCreator(wt_basecalls, use_ctrl_trace=False)
-
-    with pytest.raises(Exception) as e:
-        proposal = epc.single_cut_edit_proposal(10, "test", del_before=4)
-        proposal.human_readable_sequence()
-
-    proposal = epc.single_cut_edit_proposal(10, "test", del_before=4)
-    seq = proposal.human_readable_sequence(bp_before_cutsite=None, bp_after_cutsite=10)
-
-    assert seq == "GCACCT----|CCATAGAAAT"
+    # test far apart insertion default padding
+    far_apart_dropout_proposal = epc.multiplex_proposal(30, 90, 'g1', 'g2', dropout=False, cut1_ins=2, cut2_ins=4)
+    seq = far_apart_dropout_proposal.human_readable_sequence()
+    assert seq == ('ATCCGCTTTACAGTCACTAGACTnn|AGGACCAATTTCACGACAGGGACTAGACCTTGCTGGATAGCACCTGTCCCCATAGAAATGnnnn|GCTATGGA'
+                    'AAGCCTTTGGGTTATTT')
 
 
 def test_multiplex_cut():
@@ -65,6 +83,7 @@ def test_multiplex_cut():
 
     indep_cut2 = epc.multiplex_proposal(10, 35, "test1", "test2", cut1_del=(-4, 0), cut2_del=(3, 0))
     assert indep_cut2.sequence == "GCACCTGTCCCCATAGAAATGGCTATGGAAAGTTGGGTTATTTGCG"
+
 
 def test_bad_multiplex():
     wt_basecalls = "GCACCTGTCCCCATAGAAATGGCTATGGAAAGCCTTTGGGTTATTTGCG"

--- a/ice/tests/test_edit_proposal_creator.py
+++ b/ice/tests/test_edit_proposal_creator.py
@@ -1,6 +1,7 @@
-from ice.classes.edit_proposal_creator import  EditProposalCreator
+from ice.classes.edit_proposal_creator import EditProposalCreator
 
 import pytest
+
 
 def test_single_cut():
     wt_basecalls = "GCACCTGTCCCCATAGAAAT"
@@ -83,6 +84,7 @@ def test_wt_proposal():
 def test_req_ctrl_trace():
     with pytest.raises(Exception):
         epc = EditProposalCreator("ATCG", use_ctrl_trace=True)
+
 
 def test_generated_trace():
     seq = "ATNCG"


### PR DESCRIPTION
1. Adds a summary_json attribute to EditProposal which gives an easier to parse dict version of the summary string attribute. (Useful for frontend rendering).

Example of indel summary json:
`{'total': -24, 'details': [{'label': 'g1', 'value': 1}, {'label': 'g2', 'value': 2}, {'label': 'dropout', 'value': -27}]}`

2. Changes the EditProposal human readable sequence to always show the sequence around both cutsites if available. 

By default there is a 25 basepair padding before the cutsite and a 50 basepair padding after the cutsite. This keeps the same behavior as before this PR. However, in the case of two cutsites the basepair after gets trimmed based on how far apart the two cutsites exist. For example, if the cutsites are 10bp apart there will be a 25 bp padding before the 1st cutsite and a 40 (50 - 10) padding after the second cutsite. For cutsites more than 25 bp apart, the padding after the 2nd cutsite stays at a 25 basepairs. This means the human readable sequence for two cutsites far apart is longer than the human readable sequence for a single cutsite.

Wrote a fair amount of tests around the human readable sequence behavior which should make it clear.

