### PR TITLE
sclearn package name is deprecated. New package

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ pytest-cov==2.5.1
 matplotlib>=2.1.0
 numpy>=1.13.3
 pandas>=0.20.3
-scipy>=0.19.1
+scikit-learn>=0.19.1
 sklearn>=0.0
 xlrd>=1.1.0
 xlsxwriter>=1.0.2


### PR DESCRIPTION
name is scikit-learn. requirements.txt file updated to reflect package name change.